### PR TITLE
Add env var config for Stateset client

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,17 @@ async with client as client:
     response: Response[MyDataModel] = await get_my_data_model.asyncio_detailed(client=client)
 ```
 
+### Using the high level `Stateset` client
+
+The package exposes a convenience :class:`Stateset` class which reads the API key
+from the ``STATESET_API_KEY`` environment variable and optionally ``STATESET_BASE_URL``.
+
+```python
+from stateset import Stateset
+
+client = Stateset()  # configuration taken from the environment
+```
+
 By default, when you're calling an HTTPS API it will attempt to verify that SSL is working correctly. Using certificate verification is highly recommended most of the time, but sometimes you may need to authenticate to a server (especially an internal server) using a custom certificate bundle.
 
 ```python

--- a/__init__.py
+++ b/__init__.py
@@ -7,15 +7,16 @@ inventory management, and more.
 Basic usage:
     ```python
     from stateset import Stateset
-    
-    # Initialize the client
-    client = Stateset(api_key="your_api_key")
-    
+
+    # Initialize the client using environment variables
+    # STATESET_API_KEY and optional STATESET_BASE_URL
+    client = Stateset()
+
     # Make API calls
     async with client:
         # Get a list of returns
         returns = await client.returns.list()
-        
+
         # Create a new order
         order = await client.orders.create({
             "customer_id": "cust_123",


### PR DESCRIPTION
## Summary
- support using environment variables for the `Stateset` client
- document the new behaviour in the module docstring and README

## Testing
- `pytest -q` *(fails: command not found)*