### PR TITLE
Improve Python client SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Now call your endpoint and use your models:
 ```python
 from stateset_client.models import MyDataModel
 from stateset_client.api.my_tag import get_my_data_model
-from stateset_client.types import Response
+from stateset_client.stateset_types import Response
 
 with client as client:
     my_data: MyDataModel = get_my_data_model.sync(client=client)
@@ -36,7 +36,7 @@ Or do the same thing with an async version:
 ```python
 from stateset_client.models import MyDataModel
 from stateset_client.api.my_tag import get_my_data_model
-from stateset_client.types import Response
+from stateset_client.stateset_types import Response
 
 async with client as client:
     my_data: MyDataModel = await get_my_data_model.asyncio(client=client)

--- a/__init__.py
+++ b/__init__.py
@@ -25,7 +25,7 @@ Basic usage:
 """
 
 from .client import AuthenticatedClient, Client, Stateset
-from .types import (
+from .stateset_types import (
     StatesetID,
     Timestamp,
     Metadata,
@@ -37,6 +37,7 @@ from .types import (
     PaginatedList,
     File,
     FileUploadError,
+    Response,
     UNSET
 )
 from .errors import (
@@ -76,6 +77,7 @@ __all__ = [
     "PaginatedList",
     "File",
     "FileUploadError",
+    "Response",
     "UNSET",
     
     # Errors

--- a/api/accounts/get_account_by_name.py
+++ b/api/accounts/get_account_by_name.py
@@ -5,7 +5,7 @@ import httpx
 
 from ... import errors
 from ...client import AuthenticatedClient, Client
-from ...types import UNSET, Response
+from ...stateset_types import UNSET, Response
 
 
 def _get_kwargs(

--- a/api/bill_of_materials/create_billof_materials.py
+++ b/api/bill_of_materials/create_billof_materials.py
@@ -6,7 +6,7 @@ import httpx
 from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.bill_of_materials import BillOfMaterials
-from ...types import Response
+from ...stateset_types import Response
 
 
 def _get_kwargs(

--- a/api/bill_of_materials/delete_bill_of_materials.py
+++ b/api/bill_of_materials/delete_bill_of_materials.py
@@ -5,7 +5,7 @@ import httpx
 
 from ... import errors
 from ...client import AuthenticatedClient, Client
-from ...types import Response
+from ...stateset_types import Response
 
 
 def _get_kwargs(

--- a/api/bill_of_materials/get_bill_of_materials_by_id.py
+++ b/api/bill_of_materials/get_bill_of_materials_by_id.py
@@ -6,7 +6,7 @@ import httpx
 from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.bill_of_materials import BillOfMaterials
-from ...types import Response
+from ...stateset_types import Response
 
 
 def _get_kwargs(

--- a/api/bill_of_materials/get_billof_materials.py
+++ b/api/bill_of_materials/get_billof_materials.py
@@ -6,7 +6,7 @@ import httpx
 from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.bill_of_materials import BillOfMaterials
-from ...types import UNSET, Response
+from ...stateset_types import UNSET, Response
 
 
 def _get_kwargs(

--- a/api/bill_of_materials/update_bill_of_materials.py
+++ b/api/bill_of_materials/update_bill_of_materials.py
@@ -6,7 +6,7 @@ import httpx
 from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.bill_of_materials import BillOfMaterials
-from ...types import Response
+from ...stateset_types import Response
 
 
 def _get_kwargs(

--- a/api/bill_of_materials_line_items/get_bill_of_materials_item_by_id.py
+++ b/api/bill_of_materials_line_items/get_bill_of_materials_item_by_id.py
@@ -6,7 +6,7 @@ import httpx
 from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.bill_of_materials_line_item import BillOfMaterialsLineItem
-from ...types import UNSET, Response
+from ...stateset_types import UNSET, Response
 
 
 def _get_kwargs(

--- a/api/bill_of_materials_line_items/get_bill_of_materials_line_item_by_id.py
+++ b/api/bill_of_materials_line_items/get_bill_of_materials_line_item_by_id.py
@@ -6,7 +6,7 @@ import httpx
 from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.manufacture_order_line_item import ManufactureOrderLineItem
-from ...types import Response
+from ...stateset_types import Response
 
 
 def _get_kwargs(

--- a/api/bill_of_materials_line_items/update_bill_of_materials_line_item.py
+++ b/api/bill_of_materials_line_items/update_bill_of_materials_line_item.py
@@ -6,7 +6,7 @@ import httpx
 from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.manufacture_order_line_item import ManufactureOrderLineItem
-from ...types import Response
+from ...stateset_types import Response
 
 
 def _get_kwargs(

--- a/api/customers/delete_customers.py
+++ b/api/customers/delete_customers.py
@@ -5,7 +5,7 @@ import httpx
 
 from ... import errors
 from ...client import AuthenticatedClient, Client
-from ...types import Response
+from ...stateset_types import Response
 
 
 def _get_kwargs(

--- a/api/customers/get_customers.py
+++ b/api/customers/get_customers.py
@@ -6,7 +6,7 @@ import httpx
 from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.customers import Customers
-from ...types import UNSET, Response
+from ...stateset_types import UNSET, Response
 
 
 def _get_kwargs(

--- a/api/customers/update_customers.py
+++ b/api/customers/update_customers.py
@@ -6,7 +6,7 @@ import httpx
 from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.customers import Customers
-from ...types import Response
+from ...stateset_types import Response
 
 
 def _get_kwargs(

--- a/api/inventory_items/create_inventory_items.py
+++ b/api/inventory_items/create_inventory_items.py
@@ -6,7 +6,7 @@ import httpx
 from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.inventory_items import InventoryItems
-from ...types import Response
+from ...stateset_types import Response
 
 
 def _get_kwargs(

--- a/api/inventory_items/get_inventory_item_by_id.py
+++ b/api/inventory_items/get_inventory_item_by_id.py
@@ -6,7 +6,7 @@ import httpx
 from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.inventory_items import InventoryItems
-from ...types import Response
+from ...stateset_types import Response
 
 
 def _get_kwargs(

--- a/api/inventory_items/get_inventory_items.py
+++ b/api/inventory_items/get_inventory_items.py
@@ -6,7 +6,7 @@ import httpx
 from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.inventory_items import InventoryItems
-from ...types import UNSET, Response
+from ...stateset_types import UNSET, Response
 
 
 def _get_kwargs(

--- a/api/inventory_items/update_inventory_item.py
+++ b/api/inventory_items/update_inventory_item.py
@@ -6,7 +6,7 @@ import httpx
 from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.inventory_items import InventoryItems
-from ...types import Response
+from ...stateset_types import Response
 
 
 def _get_kwargs(

--- a/api/manufacture_order_line_items/get_manufacture_item_by_id.py
+++ b/api/manufacture_order_line_items/get_manufacture_item_by_id.py
@@ -6,7 +6,7 @@ import httpx
 from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.manufacture_order_line_item import ManufactureOrderLineItem
-from ...types import UNSET, Response
+from ...stateset_types import UNSET, Response
 
 
 def _get_kwargs(

--- a/api/manufacture_order_line_items/get_manufacture_line_item_by_id.py
+++ b/api/manufacture_order_line_items/get_manufacture_line_item_by_id.py
@@ -6,7 +6,7 @@ import httpx
 from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.manufacture_order_line_item import ManufactureOrderLineItem
-from ...types import Response
+from ...stateset_types import Response
 
 
 def _get_kwargs(

--- a/api/manufacture_order_line_items/update_manufacture_line_item.py
+++ b/api/manufacture_order_line_items/update_manufacture_line_item.py
@@ -6,7 +6,7 @@ import httpx
 from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.manufacture_order_line_item import ManufactureOrderLineItem
-from ...types import Response
+from ...stateset_types import Response
 
 
 def _get_kwargs(

--- a/api/manufacture_orders/get_manufacture_order_by_id.py
+++ b/api/manufacture_orders/get_manufacture_order_by_id.py
@@ -6,7 +6,7 @@ import httpx
 from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.manufacture_order import ManufactureOrder
-from ...types import Response
+from ...stateset_types import Response
 
 
 def _get_kwargs(

--- a/api/manufacture_orders/get_manufacture_orders.py
+++ b/api/manufacture_orders/get_manufacture_orders.py
@@ -6,7 +6,7 @@ import httpx
 from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.manufacture_order import ManufactureOrder
-from ...types import UNSET, Response
+from ...stateset_types import UNSET, Response
 
 
 def _get_kwargs(

--- a/api/manufacture_orders/update_manufacture_order.py
+++ b/api/manufacture_orders/update_manufacture_order.py
@@ -6,7 +6,7 @@ import httpx
 from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.manufacture_order import ManufactureOrder
-from ...types import Response
+from ...stateset_types import Response
 
 
 def _get_kwargs(

--- a/api/messages/create_message.py
+++ b/api/messages/create_message.py
@@ -6,7 +6,7 @@ import httpx
 from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.messages import Messages
-from ...types import Response
+from ...stateset_types import Response
 
 
 def _get_kwargs(

--- a/api/messages/delete_message.py
+++ b/api/messages/delete_message.py
@@ -5,7 +5,7 @@ import httpx
 
 from ... import errors
 from ...client import AuthenticatedClient, Client
-from ...types import Response
+from ...stateset_types import Response
 
 
 def _get_kwargs(

--- a/api/messages/get_message_by_id.py
+++ b/api/messages/get_message_by_id.py
@@ -6,7 +6,7 @@ import httpx
 from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.messages import Messages
-from ...types import Response
+from ...stateset_types import Response
 
 
 def _get_kwargs(

--- a/api/messages/get_messages.py
+++ b/api/messages/get_messages.py
@@ -6,7 +6,7 @@ import httpx
 from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.messages import Messages
-from ...types import UNSET, Response
+from ...stateset_types import UNSET, Response
 
 
 def _get_kwargs(

--- a/api/messages/update_message.py
+++ b/api/messages/update_message.py
@@ -6,7 +6,7 @@ import httpx
 from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.messages import Messages
-from ...types import Response
+from ...stateset_types import Response
 
 
 def _get_kwargs(

--- a/api/notes/create_note.py
+++ b/api/notes/create_note.py
@@ -6,7 +6,7 @@ import httpx
 from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.notes import Notes
-from ...types import Response
+from ...stateset_types import Response
 
 
 def _get_kwargs(

--- a/api/notes/delete_inventory_item.py
+++ b/api/notes/delete_inventory_item.py
@@ -5,7 +5,7 @@ import httpx
 
 from ... import errors
 from ...client import AuthenticatedClient, Client
-from ...types import Response
+from ...stateset_types import Response
 
 
 def _get_kwargs(

--- a/api/notes/delete_notes.py
+++ b/api/notes/delete_notes.py
@@ -5,7 +5,7 @@ import httpx
 
 from ... import errors
 from ...client import AuthenticatedClient, Client
-from ...types import Response
+from ...stateset_types import Response
 
 
 def _get_kwargs(

--- a/api/notes/get_customers_by_id.py
+++ b/api/notes/get_customers_by_id.py
@@ -6,7 +6,7 @@ import httpx
 from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.customers import Customers
-from ...types import Response
+from ...stateset_types import Response
 
 
 def _get_kwargs(

--- a/api/notes/get_notes.py
+++ b/api/notes/get_notes.py
@@ -6,7 +6,7 @@ import httpx
 from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.notes import Notes
-from ...types import UNSET, Response
+from ...stateset_types import UNSET, Response
 
 
 def _get_kwargs(

--- a/api/notes/get_notes_by_id.py
+++ b/api/notes/get_notes_by_id.py
@@ -6,7 +6,7 @@ import httpx
 from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.notes import Notes
-from ...types import Response
+from ...stateset_types import Response
 
 
 def _get_kwargs(

--- a/api/notes/update_notes.py
+++ b/api/notes/update_notes.py
@@ -6,7 +6,7 @@ import httpx
 from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.notes import Notes
-from ...types import Response
+from ...stateset_types import Response
 
 
 def _get_kwargs(

--- a/api/return_line_items/get_return_item_by_id.py
+++ b/api/return_line_items/get_return_item_by_id.py
@@ -6,7 +6,7 @@ import httpx
 from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.return_item import ReturnItem
-from ...types import UNSET, Response
+from ...stateset_types import UNSET, Response
 
 
 def _get_kwargs(

--- a/api/return_line_items/get_return_line_item_by_id.py
+++ b/api/return_line_items/get_return_line_item_by_id.py
@@ -6,7 +6,7 @@ import httpx
 from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.return_item import ReturnItem
-from ...types import Response
+from ...stateset_types import Response
 
 
 def _get_kwargs(

--- a/api/return_line_items/update_return_line_item.py
+++ b/api/return_line_items/update_return_line_item.py
@@ -6,7 +6,7 @@ import httpx
 from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.return_item import ReturnItem
-from ...types import Response
+from ...stateset_types import Response
 
 
 def _get_kwargs(

--- a/api/returns/create_return.py
+++ b/api/returns/create_return.py
@@ -6,7 +6,7 @@ import httpx
 from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.return_ import Return
-from ...types import Response
+from ...stateset_types import Response
 
 
 def _get_kwargs(

--- a/api/returns/delete_return.py
+++ b/api/returns/delete_return.py
@@ -5,7 +5,7 @@ import httpx
 
 from ... import errors
 from ...client import AuthenticatedClient, Client
-from ...types import Response
+from ...stateset_types import Response
 
 
 def _get_kwargs(

--- a/api/returns/get_return_by_id.py
+++ b/api/returns/get_return_by_id.py
@@ -6,7 +6,7 @@ import httpx
 from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.return_ import Return
-from ...types import Response
+from ...stateset_types import Response
 
 
 def _get_kwargs(

--- a/api/returns/get_returns.py
+++ b/api/returns/get_returns.py
@@ -6,7 +6,7 @@ import httpx
 from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.return_ import Return
-from ...types import UNSET, Response
+from ...stateset_types import UNSET, Response
 
 
 def _get_kwargs(

--- a/api/returns/update_return.py
+++ b/api/returns/update_return.py
@@ -6,7 +6,7 @@ import httpx
 from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.return_ import Return
-from ...types import Response
+from ...stateset_types import Response
 
 
 def _get_kwargs(

--- a/api/warranties/create_warranty.py
+++ b/api/warranties/create_warranty.py
@@ -6,7 +6,7 @@ import httpx
 from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.warranty import Warranty
-from ...types import Response
+from ...stateset_types import Response
 
 
 def _get_kwargs(

--- a/api/warranties/get_warranties.py
+++ b/api/warranties/get_warranties.py
@@ -6,7 +6,7 @@ import httpx
 from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.warranty import Warranty
-from ...types import UNSET, Response
+from ...stateset_types import UNSET, Response
 
 
 def _get_kwargs(

--- a/api/warranty/delete_warranty.py
+++ b/api/warranty/delete_warranty.py
@@ -5,7 +5,7 @@ import httpx
 
 from ... import errors
 from ...client import AuthenticatedClient, Client
-from ...types import Response
+from ...stateset_types import Response
 
 
 def _get_kwargs(

--- a/api/warranty/get_warranty_by_id.py
+++ b/api/warranty/get_warranty_by_id.py
@@ -6,7 +6,7 @@ import httpx
 from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.warranty import Warranty
-from ...types import Response
+from ...stateset_types import Response
 
 
 def _get_kwargs(

--- a/api/warranty/update_warranty.py
+++ b/api/warranty/update_warranty.py
@@ -6,7 +6,7 @@ import httpx
 from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.warranty import Warranty
-from ...types import Response
+from ...stateset_types import Response
 
 
 def _get_kwargs(

--- a/api/warranty_line_items/get_warranty_item_by_id.py
+++ b/api/warranty_line_items/get_warranty_item_by_id.py
@@ -6,7 +6,7 @@ import httpx
 from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.warranty_item import WarrantyItem
-from ...types import UNSET, Response
+from ...stateset_types import UNSET, Response
 
 
 def _get_kwargs(

--- a/api/warranty_line_items/get_warranty_line_item_by_id.py
+++ b/api/warranty_line_items/get_warranty_line_item_by_id.py
@@ -6,7 +6,7 @@ import httpx
 from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.warranty_item import WarrantyItem
-from ...types import Response
+from ...stateset_types import Response
 
 
 def _get_kwargs(

--- a/api/warranty_line_items/update_warranty_line_item.py
+++ b/api/warranty_line_items/update_warranty_line_item.py
@@ -6,7 +6,7 @@ import httpx
 from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.warranty_item import WarrantyItem
-from ...types import Response
+from ...stateset_types import Response
 
 
 def _get_kwargs(

--- a/api/work_order_line_items/get_work_item_by_id.py
+++ b/api/work_order_line_items/get_work_item_by_id.py
@@ -6,7 +6,7 @@ import httpx
 from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.work_order_line_items import WorkOrderLineItems
-from ...types import UNSET, Response
+from ...stateset_types import UNSET, Response
 
 
 def _get_kwargs(

--- a/api/work_order_line_items/get_work_line_item_by_id.py
+++ b/api/work_order_line_items/get_work_line_item_by_id.py
@@ -6,7 +6,7 @@ import httpx
 from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.work_order_line_items import WorkOrderLineItems
-from ...types import Response
+from ...stateset_types import Response
 
 
 def _get_kwargs(

--- a/api/work_order_line_items/update_work_line_item.py
+++ b/api/work_order_line_items/update_work_line_item.py
@@ -6,7 +6,7 @@ import httpx
 from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.work_order_line_items import WorkOrderLineItems
-from ...types import Response
+from ...stateset_types import Response
 
 
 def _get_kwargs(

--- a/api/work_orders/get_work_order_by_id.py
+++ b/api/work_orders/get_work_order_by_id.py
@@ -6,7 +6,7 @@ import httpx
 from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.work_order import WorkOrder
-from ...types import Response
+from ...stateset_types import Response
 
 
 def _get_kwargs(

--- a/api/work_orders/get_work_ordes.py
+++ b/api/work_orders/get_work_ordes.py
@@ -6,7 +6,7 @@ import httpx
 from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.work_order import WorkOrder
-from ...types import UNSET, Response
+from ...stateset_types import UNSET, Response
 
 
 def _get_kwargs(

--- a/api/work_orders/update_work_order.py
+++ b/api/work_orders/update_work_order.py
@@ -6,7 +6,7 @@ import httpx
 from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.work_order import WorkOrder
-from ...types import Response
+from ...stateset_types import Response
 
 
 def _get_kwargs(

--- a/base_resource.py
+++ b/base_resource.py
@@ -4,7 +4,7 @@ Base resource class that implements common functionality for all Stateset API re
 
 from typing import Any, Dict, Generic, List, Optional, Type, TypeVar
 from .client import AuthenticatedClient
-from .types import PaginatedList, PaginationParams, StatesetObject
+from .stateset_types import PaginatedList, PaginationParams, StatesetObject
 
 T = TypeVar('T', bound=StatesetObject)
 

--- a/client.py
+++ b/client.py
@@ -3,6 +3,8 @@ import httpx
 from httpx import Timeout
 from attrs import define, field
 
+from .errors import raise_for_status_code
+
 
 class Client:
     """HTTP client wrapper used by the generated endpoints."""
@@ -53,22 +55,22 @@ class Client:
     # Convenience async request helpers ---------------------------------------
     async def get(self, path: str, **kwargs: Any) -> Dict[str, Any]:
         response = await self.get_async_httpx_client().get(path, **kwargs)
-        response.raise_for_status()
+        raise_for_status_code(response.status_code, response.content)
         return response.json()
 
     async def post(self, path: str, **kwargs: Any) -> Dict[str, Any]:
         response = await self.get_async_httpx_client().post(path, **kwargs)
-        response.raise_for_status()
+        raise_for_status_code(response.status_code, response.content)
         return response.json()
 
     async def put(self, path: str, **kwargs: Any) -> Dict[str, Any]:
         response = await self.get_async_httpx_client().put(path, **kwargs)
-        response.raise_for_status()
+        raise_for_status_code(response.status_code, response.content)
         return response.json()
 
     async def delete(self, path: str, **kwargs: Any) -> None:
         response = await self.get_async_httpx_client().delete(path, **kwargs)
-        response.raise_for_status()
+        raise_for_status_code(response.status_code, response.content)
 
     # Lifecycle management -----------------------------------------------------
     def __enter__(self) -> "Client":
@@ -225,7 +227,7 @@ class Stateset:
                 url=path,
                 json=data
             )
-            response.raise_for_status()
+            raise_for_status_code(response.status_code, response.content)
             return response.json()
             
         except Exception as e:

--- a/models/bill_of_materials.py
+++ b/models/bill_of_materials.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, List, Type, TypeVar, Union
 from attrs import define, field
 from dateutil.parser import isoparse
 
-from ..types import UNSET, Unset
+from ..stateset_types import UNSET, Unset
 
 T = TypeVar("T", bound="BillOfMaterials")
 

--- a/models/bill_of_materials_line_item.py
+++ b/models/bill_of_materials_line_item.py
@@ -2,7 +2,7 @@ from typing import Any, Dict, List, Type, TypeVar, Union
 
 from attrs import define, field
 
-from ..types import UNSET, Unset
+from ..stateset_types import UNSET, Unset
 
 T = TypeVar("T", bound="BillOfMaterialsLineItem")
 

--- a/models/customers.py
+++ b/models/customers.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, List, Type, TypeVar, Union
 from attrs import define, field
 from dateutil.parser import isoparse
 
-from ..types import UNSET, Unset
+from ..stateset_types import UNSET, Unset
 
 T = TypeVar("T", bound="Customers")
 

--- a/models/inventory_items.py
+++ b/models/inventory_items.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, List, Type, TypeVar, Union
 from attrs import define, field
 from dateutil.parser import isoparse
 
-from ..types import UNSET, Unset
+from ..stateset_types import UNSET, Unset
 
 T = TypeVar("T", bound="InventoryItems")
 

--- a/models/manufacture_order.py
+++ b/models/manufacture_order.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, List, Type, TypeVar, Union
 from attrs import define, field
 from dateutil.parser import isoparse
 
-from ..types import UNSET, Unset
+from ..stateset_types import UNSET, Unset
 
 T = TypeVar("T", bound="ManufactureOrder")
 

--- a/models/manufacture_order_line_item.py
+++ b/models/manufacture_order_line_item.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, List, Type, TypeVar, Union
 from attrs import define, field
 from dateutil.parser import isoparse
 
-from ..types import UNSET, Unset
+from ..stateset_types import UNSET, Unset
 
 T = TypeVar("T", bound="ManufactureOrderLineItem")
 

--- a/models/messages.py
+++ b/models/messages.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, List, Type, TypeVar, Union
 from attrs import define, field
 from dateutil.parser import isoparse
 
-from ..types import UNSET, Unset
+from ..stateset_types import UNSET, Unset
 
 T = TypeVar("T", bound="Messages")
 

--- a/models/notes.py
+++ b/models/notes.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, List, Type, TypeVar, Union
 from attrs import define, field
 from dateutil.parser import isoparse
 
-from ..types import UNSET, Unset
+from ..stateset_types import UNSET, Unset
 
 T = TypeVar("T", bound="Notes")
 

--- a/models/problem.py
+++ b/models/problem.py
@@ -2,7 +2,7 @@ from typing import Any, Dict, List, Type, TypeVar, Union
 
 from attrs import define, field
 
-from ..types import UNSET, Unset
+from ..stateset_types import UNSET, Unset
 
 T = TypeVar("T", bound="Problem")
 

--- a/models/return_.py
+++ b/models/return_.py
@@ -2,7 +2,7 @@ from typing import Any, Dict, List, Type, TypeVar, Union
 
 from attrs import define, field
 
-from ..types import UNSET, Unset
+from ..stateset_types import UNSET, Unset
 
 T = TypeVar("T", bound="Return")
 

--- a/models/return_item.py
+++ b/models/return_item.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, List, Type, TypeVar, Union
 from attrs import define, field
 from dateutil.parser import isoparse
 
-from ..types import UNSET, Unset
+from ..stateset_types import UNSET, Unset
 
 T = TypeVar("T", bound="ReturnItem")
 

--- a/models/warranty.py
+++ b/models/warranty.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Any, BinaryIO, Dict, List, Optional, TextIO, T
 from attrs import define, field
 from dateutil.parser import isoparse
 
-from ..types import UNSET, Unset
+from ..stateset_types import UNSET, Unset
 
 T = TypeVar("T", bound="Warranty")
 
@@ -312,7 +312,6 @@ class Warranty:
             amount=amount,
             tax_refunded=tax_refunded,
             total_refunded=total_refunded,
-            created_date=created_date,
             serial_number=serial_number,
             reason_category=reason_category,
         )

--- a/models/warranty_item.py
+++ b/models/warranty_item.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, List, Type, TypeVar, Union
 from attrs import define, field
 from dateutil.parser import isoparse
 
-from ..types import UNSET, Unset
+from ..stateset_types import UNSET, Unset
 
 T = TypeVar("T", bound="WarrantyItem")
 

--- a/models/work_order.py
+++ b/models/work_order.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, List, Type, TypeVar, Union
 from attrs import define, field
 from dateutil.parser import isoparse
 
-from ..types import UNSET, Unset
+from ..stateset_types import UNSET, Unset
 
 T = TypeVar("T", bound="WorkOrder")
 

--- a/models/work_order_line_items.py
+++ b/models/work_order_line_items.py
@@ -2,7 +2,7 @@ from typing import Any, Dict, List, Type, TypeVar, Union
 
 from attrs import define, field
 
-from ..types import UNSET, Unset
+from ..stateset_types import UNSET, Unset
 
 T = TypeVar("T", bound="WorkOrderLineItems")
 

--- a/resources/order_resource.py
+++ b/resources/order_resource.py
@@ -7,7 +7,7 @@ from datetime import datetime
 from attrs import define, field
 
 from .base_resource import BaseResource
-from .types import StatesetObject, StatesetID, OrderStatus, Metadata
+from .stateset_types import StatesetObject, StatesetID, OrderStatus, Metadata
 
 @define
 class OrderItem:

--- a/stateset_types.py
+++ b/stateset_types.py
@@ -18,6 +18,7 @@ from typing import (
     List,
     Literal,
     Mapping,
+    MutableMapping,
     Optional,
     Protocol,
     TextIO,
@@ -25,6 +26,7 @@ from typing import (
     TypeVar,
     Union,
 )
+from http import HTTPStatus
 from pathlib import Path
 import mimetypes
 import json
@@ -213,6 +215,16 @@ class File:
         except Exception as e:
             raise FileUploadError(f"Failed to prepare file for upload: {str(e)}")
 
+
+@dataclass
+class Response(Generic[T]):
+    """Represents an HTTP response from the Stateset API."""
+
+    status_code: HTTPStatus
+    content: bytes
+    headers: MutableMapping[str, str]
+    parsed: Optional[T]
+
 __all__ = [
     "StatesetID",
     "Timestamp",
@@ -225,6 +237,7 @@ __all__ = [
     "PaginatedList",
     "File",
     "FileUploadError",
+    "Response",
     "UNSET",
     "UnsetType",
     "OptionalUnset",


### PR DESCRIPTION
## Summary
- rename `types.py` to `stateset_types.py`
- restore `Response` dataclass and export it
- update all imports to use `stateset_types`
- improve HTTP error handling in `Client`
- fix duplicated argument in `models/warranty.py`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m unittest discover` *(fails: ModuleNotFoundError: No module named 'attrs')*