### PR TITLE
Improve Python client SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,10 @@ from stateset import Stateset
 client = Stateset()  # configuration taken from the environment
 ```
 
+The SDK automatically sets a ``User-Agent`` header on all requests in the form
+``stateset-python/<version>`` so that your integration can be identified by the
+Stateset API.
+
 By default, when you're calling an HTTPS API it will attempt to verify that SSL is working correctly. Using certificate verification is highly recommended most of the time, but sometimes you may need to authenticate to a server (especially an internal server) using a custom certificate bundle.
 
 ```python

--- a/client.py
+++ b/client.py
@@ -1,5 +1,7 @@
 from typing import Optional, Dict, Any, Mapping
 import os
+
+from . import __version__
 import httpx
 from httpx import Timeout
 from attrs import define, field
@@ -22,6 +24,7 @@ class Client:
     ) -> None:
         self.base_url = base_url.rstrip("/")
         self.headers = dict(headers or {})
+        self.headers.setdefault("User-Agent", f"stateset-python/{__version__}")
         self.timeout = timeout if isinstance(timeout, Timeout) else Timeout(timeout or 5.0)
         self.follow_redirects = follow_redirects
         self.verify_ssl = verify_ssl


### PR DESCRIPTION
## Summary
- add a default `User-Agent` header in `Client`
- document the header behaviour in README

## Testing
- `python -m py_compile client.py __init__.py stateset_types.py errors.py base_resource.py resources/order_resource.py`