### PR TITLE
Improve HTTPX client customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,8 @@ client = Client(
 )
 # Note that base_url needs to be re-set, as would any shared cookies, headers, etc.
 client.set_httpx_client(httpx.Client(base_url="https://api.stateset.com", proxies="http://localhost:8030"))
+async_client = httpx.AsyncClient(base_url="https://api.stateset.com", proxies="http://localhost:8030")
+client.set_async_httpx_client(async_client)
 ```
 
 ## Building / publishing this package


### PR DESCRIPTION
## Summary
- add `set_httpx_client` and `set_async_httpx_client` methods to `Client`
- document how to configure an async client in README

## Testing
- `pytest -q` *(fails: command not found)*