### PR TITLE
Rename support tickets resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,14 @@ client = Stateset()
 client.close()
 ```
 
+Once you have a client instance you can access customer service APIs like
+case tickets:
+
+```python
+async with client:
+    tickets = await client.case_tickets.list()
+```
+
 The SDK automatically sets a ``User-Agent`` header on all requests in the form
 ``stateset-python/<version>`` so that your integration can be identified by the
 Stateset API.

--- a/__init__.py
+++ b/__init__.py
@@ -117,6 +117,7 @@ if TYPE_CHECKING:
     from .resources.customer_resource import Customers
     from .resources.message_resource import Messages
     from .resources.note_resource import Notes
+    from .resources.case_ticket_resource import CaseTickets
     from .resources.return_line_resource import ReturnLines
     from .resources.warranty_line_resource import WarrantyLines
 

--- a/client.py
+++ b/client.py
@@ -178,6 +178,7 @@ from .resources.manufacture_order_resource import ManufactureOrders
 from .resources.channel_resource import Channels
 from .resources.message_resource import Messages
 from .resources.note_resource import Notes
+from .resources.case_ticket_resource import CaseTickets
 from .resources.agent_resource import Agents
 from .resources.rule_resource import Rules
 from .resources.attribute_resource import Attributes
@@ -266,6 +267,7 @@ class Stateset:
         self.channels = Channels(self._client)
         self.messages = Messages(self._client)
         self.notes = Notes(self._client)
+        self.case_tickets = CaseTickets(self._client)
         self.agents = Agents(self._client)
         self.rules = Rules(self._client)
         self.attributes = Attributes(self._client)

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -9,6 +9,7 @@ from .manufacture_order_line_item import ManufactureOrderLineItem
 from .messages import Messages
 from .notes import Notes
 from .problem import Problem
+from .case_ticket import CaseTicket
 from .return_ import Return
 from .return_item import ReturnItem
 from .warranty import Warranty
@@ -26,6 +27,7 @@ __all__ = (
     "Messages",
     "Notes",
     "Problem",
+    "CaseTicket",
     "Return",
     "ReturnItem",
     "Warranty",

--- a/models/case_ticket.py
+++ b/models/case_ticket.py
@@ -1,0 +1,110 @@
+import datetime
+from typing import Any, Dict, List, Type, TypeVar, Union
+
+from attrs import define, field
+from dateutil.parser import isoparse
+
+from ..stateset_types import UNSET, Unset
+
+T = TypeVar("T", bound="CaseTicket")
+
+
+@define
+class CaseTicket:
+    """Represents a customer service case ticket."""
+
+    id: Union[Unset, str] = UNSET
+    customer_id: Union[Unset, str] = UNSET
+    subject: Union[Unset, str] = UNSET
+    description: Union[Unset, str] = UNSET
+    status: Union[Unset, str] = UNSET
+    priority: Union[Unset, str] = UNSET
+    created_at: Union[Unset, datetime.datetime] = UNSET
+    updated_at: Union[Unset, datetime.datetime] = UNSET
+    additional_properties: Dict[str, Any] = field(init=False, factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        id = self.id
+        customer_id = self.customer_id
+        subject = self.subject
+        description = self.description
+        status = self.status
+        priority = self.priority
+        created_at: Union[Unset, str] = UNSET
+        if not isinstance(self.created_at, Unset):
+            created_at = self.created_at.isoformat()
+        updated_at: Union[Unset, str] = UNSET
+        if not isinstance(self.updated_at, Unset):
+            updated_at = self.updated_at.isoformat()
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({})
+        if id is not UNSET:
+            field_dict["id"] = id
+        if customer_id is not UNSET:
+            field_dict["customer_id"] = customer_id
+        if subject is not UNSET:
+            field_dict["subject"] = subject
+        if description is not UNSET:
+            field_dict["description"] = description
+        if status is not UNSET:
+            field_dict["status"] = status
+        if priority is not UNSET:
+            field_dict["priority"] = priority
+        if created_at is not UNSET:
+            field_dict["created_at"] = created_at
+        if updated_at is not UNSET:
+            field_dict["updated_at"] = updated_at
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        d = src_dict.copy()
+        id = d.pop("id", UNSET)
+        customer_id = d.pop("customer_id", UNSET)
+        subject = d.pop("subject", UNSET)
+        description = d.pop("description", UNSET)
+        status = d.pop("status", UNSET)
+        priority = d.pop("priority", UNSET)
+        _created_at = d.pop("created_at", UNSET)
+        created_at: Union[Unset, datetime.datetime]
+        if isinstance(_created_at, Unset):
+            created_at = UNSET
+        else:
+            created_at = isoparse(_created_at)
+        _updated_at = d.pop("updated_at", UNSET)
+        updated_at: Union[Unset, datetime.datetime]
+        if isinstance(_updated_at, Unset):
+            updated_at = UNSET
+        else:
+            updated_at = isoparse(_updated_at)
+        case_ticket = cls(
+            id=id,
+            customer_id=customer_id,
+            subject=subject,
+            description=description,
+            status=status,
+            priority=priority,
+            created_at=created_at,
+            updated_at=updated_at,
+        )
+
+        case_ticket.additional_properties = d
+        return case_ticket
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/resources/case_ticket_resource.py
+++ b/resources/case_ticket_resource.py
@@ -1,0 +1,13 @@
+from attrs import define
+
+from ..client import AuthenticatedClient
+from ..models.case_ticket import CaseTicket
+from ..base_resource import BaseResource
+
+
+@define
+class CaseTickets(BaseResource[CaseTicket]):
+    """Operations on Stateset Case Tickets."""
+
+    def __init__(self, client: AuthenticatedClient) -> None:
+        super().__init__(client, CaseTicket, "/case_tickets")


### PR DESCRIPTION
## Summary
- rename `SupportTicket` model to `CaseTicket`
- add `CaseTickets` resource and load it in the client
- document new `case_tickets` example usage

## Testing
- `python -m py_compile models/case_ticket.py resources/case_ticket_resource.py models/__init__.py __init__.py client.py`
- `pytest -q` *(fails: command not found)*