### PR TITLE
Add order API support

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,13 @@ case tickets:
 ```python
 async with client:
     tickets = await client.case_tickets.list()
+    # Create a new order
+    order = await client.orders.create({
+        "customer_id": "cust_123",
+        "status": "pending",
+        "items": [{"product_id": "prod_456", "quantity": 1, "price": 10.0}],
+        "total_amount": 10.0,
+    })
 ```
 
 The SDK automatically sets a ``User-Agent`` header on all requests in the form

--- a/api/orders/create_order.py
+++ b/api/orders/create_order.py
@@ -1,0 +1,65 @@
+from http import HTTPStatus
+from typing import Any, Dict, Optional, Union
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.order import Order
+from ...stateset_types import Response
+
+
+def _get_kwargs(*, json_body: Order) -> Dict[str, Any]:
+    pass
+
+    json_json_body = json_body.to_dict()
+
+    return {
+        "method": "post",
+        "url": "/orders",
+        "json": json_json_body,
+    }
+
+
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Optional[Any]:
+    if response.status_code == HTTPStatus.CREATED:
+        return None
+    if response.status_code == HTTPStatus.BAD_REQUEST:
+        return None
+    if response.status_code == HTTPStatus.METHOD_NOT_ALLOWED:
+        return None
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Response[Any]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(*, client: AuthenticatedClient, json_body: Order) -> Response[Any]:
+    """Create a new order"""
+
+    kwargs = _get_kwargs(json_body=json_body)
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio_detailed(*, client: AuthenticatedClient, json_body: Order) -> Response[Any]:
+    """Create a new order"""
+
+    kwargs = _get_kwargs(json_body=json_body)
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)

--- a/api/orders/delete_order.py
+++ b/api/orders/delete_order.py
@@ -1,0 +1,53 @@
+from http import HTTPStatus
+from typing import Any, Dict, Optional, Union
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...stateset_types import Response
+
+
+def _get_kwargs(id: str) -> Dict[str, Any]:
+    pass
+
+    return {
+        "method": "delete",
+        "url": f"/orders/{id}",
+    }
+
+
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Optional[Any]:
+    if response.status_code == HTTPStatus.BAD_REQUEST:
+        return None
+    if response.status_code == HTTPStatus.NOT_FOUND:
+        return None
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Response[Any]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(id: str, *, client: AuthenticatedClient) -> Response[Any]:
+    """Delete order"""
+
+    kwargs = _get_kwargs(id)
+    response = client.get_httpx_client().request(**kwargs)
+    return _build_response(client=client, response=response)
+
+
+async def asyncio_detailed(id: str, *, client: AuthenticatedClient) -> Response[Any]:
+    """Delete order"""
+
+    kwargs = _get_kwargs(id)
+    response = await client.get_async_httpx_client().request(**kwargs)
+    return _build_response(client=client, response=response)

--- a/api/orders/get_order_by_id.py
+++ b/api/orders/get_order_by_id.py
@@ -1,0 +1,80 @@
+from http import HTTPStatus
+from typing import Any, Dict, Optional, Union, cast
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.order import Order
+from ...stateset_types import Response
+
+
+def _get_kwargs(id: str) -> Dict[str, Any]:
+    pass
+
+    return {
+        "method": "get",
+        "url": f"/orders/{id}",
+    }
+
+
+def _parse_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Optional[Union[Any, Order]]:
+    if response.status_code == HTTPStatus.OK:
+        response_200 = Order.from_dict(response.json())
+        return response_200
+    if response.status_code == HTTPStatus.FORBIDDEN:
+        response_403 = cast(Any, None)
+        return response_403
+    if response.status_code == HTTPStatus.NOT_FOUND:
+        response_404 = cast(Any, None)
+        return response_404
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Response[Union[Any, Order]]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(id: str, *, client: AuthenticatedClient) -> Response[Union[Any, Order]]:
+    """Get order by id"""
+
+    kwargs = _get_kwargs(id)
+    response = client.get_httpx_client().request(**kwargs)
+    return _build_response(client=client, response=response)
+
+
+def sync(id: str, *, client: AuthenticatedClient) -> Optional[Union[Any, Order]]:
+    """Get order by id"""
+
+    return sync_detailed(id=id, client=client).parsed
+
+
+async def asyncio_detailed(id: str, *, client: AuthenticatedClient) -> Response[Union[Any, Order]]:
+    """Get order by id"""
+
+    kwargs = _get_kwargs(id)
+    response = await client.get_async_httpx_client().request(**kwargs)
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(id: str, *, client: AuthenticatedClient) -> Optional[Union[Any, Order]]:
+    """Get order by id"""
+
+    return (
+        await asyncio_detailed(
+            id=id,
+            client=client,
+        )
+    ).parsed

--- a/api/orders/get_orders.py
+++ b/api/orders/get_orders.py
@@ -1,0 +1,106 @@
+from http import HTTPStatus
+from typing import Any, Dict, Optional, Union, cast
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.order import Order
+from ...stateset_types import UNSET, Response
+
+
+def _get_kwargs(*, limit: float, offset: float, order_direction: str) -> Dict[str, Any]:
+    pass
+
+    params: Dict[str, Any] = {}
+    params["limit"] = limit
+    params["offset"] = offset
+    params["order_direction"] = order_direction
+    params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
+
+    return {
+        "method": "get",
+        "url": "/orders",
+        "params": params,
+    }
+
+
+def _parse_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Optional[Union[Any, Order]]:
+    if response.status_code == HTTPStatus.OK:
+        response_200 = Order.from_dict(response.json())
+        return response_200
+    if response.status_code == HTTPStatus.FORBIDDEN:
+        response_403 = cast(Any, None)
+        return response_403
+    if response.status_code == HTTPStatus.NOT_FOUND:
+        response_404 = cast(Any, None)
+        return response_404
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Response[Union[Any, Order]]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *, client: AuthenticatedClient, limit: float, offset: float, order_direction: str
+) -> Response[Union[Any, Order]]:
+    """Get orders"""
+
+    kwargs = _get_kwargs(limit=limit, offset=offset, order_direction=order_direction)
+
+    response = client.get_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *, client: AuthenticatedClient, limit: float, offset: float, order_direction: str
+) -> Optional[Union[Any, Order]]:
+    """Get orders"""
+
+    return sync_detailed(
+        client=client,
+        limit=limit,
+        offset=offset,
+        order_direction=order_direction,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *, client: AuthenticatedClient, limit: float, offset: float, order_direction: str
+) -> Response[Union[Any, Order]]:
+    """Get orders"""
+
+    kwargs = _get_kwargs(limit=limit, offset=offset, order_direction=order_direction)
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *, client: AuthenticatedClient, limit: float, offset: float, order_direction: str
+) -> Optional[Union[Any, Order]]:
+    """Get orders"""
+
+    return (
+        await asyncio_detailed(
+            client=client,
+            limit=limit,
+            offset=offset,
+            order_direction=order_direction,
+        )
+    ).parsed

--- a/api/orders/update_order.py
+++ b/api/orders/update_order.py
@@ -1,0 +1,59 @@
+from http import HTTPStatus
+from typing import Any, Dict, Optional, Union
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.order import Order
+from ...stateset_types import Response
+
+
+def _get_kwargs(id: str, *, json_body: Order) -> Dict[str, Any]:
+    pass
+
+    json_json_body = json_body.to_dict()
+
+    return {
+        "method": "put",
+        "url": f"/orders/{id}",
+        "json": json_json_body,
+    }
+
+
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Optional[Any]:
+    if response.status_code == HTTPStatus.OK:
+        return None
+    if response.status_code == HTTPStatus.BAD_REQUEST:
+        return None
+    if response.status_code == HTTPStatus.NOT_FOUND:
+        return None
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Response[Any]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(id: str, *, client: AuthenticatedClient, json_body: Order) -> Response[Any]:
+    """Update order"""
+
+    kwargs = _get_kwargs(id=id, json_body=json_body)
+    response = client.get_httpx_client().request(**kwargs)
+    return _build_response(client=client, response=response)
+
+
+async def asyncio_detailed(id: str, *, client: AuthenticatedClient, json_body: Order) -> Response[Any]:
+    """Update order"""
+
+    kwargs = _get_kwargs(id=id, json_body=json_body)
+    response = await client.get_async_httpx_client().request(**kwargs)
+    return _build_response(client=client, response=response)

--- a/models/order.py
+++ b/models/order.py
@@ -1,0 +1,181 @@
+import datetime
+from typing import Any, Dict, List, Type, TypeVar, Union
+
+from attrs import define, field
+from dateutil.parser import isoparse
+
+from ..stateset_types import UNSET, Unset, OrderStatus
+
+T = TypeVar("T", bound="Order")
+TI = TypeVar("TI", bound="OrderItem")
+
+
+@define
+class OrderItem:
+    product_id: Union[Unset, str] = UNSET
+    quantity: Union[Unset, int] = UNSET
+    price: Union[Unset, float] = UNSET
+    currency: Union[Unset, str] = UNSET
+    metadata: Dict[str, Any] = field(init=False, factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        product_id = self.product_id
+        quantity = self.quantity
+        price = self.price
+        currency = self.currency
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.metadata)
+        if product_id is not UNSET:
+            field_dict["product_id"] = product_id
+        if quantity is not UNSET:
+            field_dict["quantity"] = quantity
+        if price is not UNSET:
+            field_dict["price"] = price
+        if currency is not UNSET:
+            field_dict["currency"] = currency
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: Type[TI], src_dict: Dict[str, Any]) -> TI:
+        d = src_dict.copy()
+        product_id = d.pop("product_id", UNSET)
+        quantity = d.pop("quantity", UNSET)
+        price = d.pop("price", UNSET)
+        currency = d.pop("currency", UNSET)
+
+        order_item = cls(
+            product_id=product_id,
+            quantity=quantity,
+            price=price,
+            currency=currency,
+        )
+
+        order_item.metadata = d
+        return order_item
+
+
+@define
+class Order:
+    id: Union[Unset, str] = UNSET
+    customer_id: Union[Unset, str] = UNSET
+    status: Union[Unset, OrderStatus] = UNSET
+    items: Union[Unset, List[OrderItem]] = UNSET
+    total_amount: Union[Unset, float] = UNSET
+    currency: Union[Unset, str] = UNSET
+    shipping_address: Union[Unset, Dict[str, str]] = UNSET
+    tracking_number: Union[Unset, str] = UNSET
+    created_at: Union[Unset, datetime.datetime] = UNSET
+    updated_at: Union[Unset, datetime.datetime] = UNSET
+    additional_properties: Dict[str, Any] = field(init=False, factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        id = self.id
+        customer_id = self.customer_id
+        status: Union[Unset, str] = UNSET
+        if not isinstance(self.status, Unset):
+            status = self.status.value
+        items: Union[Unset, List[Dict[str, Any]]] = UNSET
+        if not isinstance(self.items, Unset):
+            items = [item.to_dict() for item in self.items]
+        total_amount = self.total_amount
+        currency = self.currency
+        shipping_address = self.shipping_address
+        tracking_number = self.tracking_number
+        created_at: Union[Unset, str] = UNSET
+        if not isinstance(self.created_at, Unset):
+            created_at = self.created_at.isoformat()
+        updated_at: Union[Unset, str] = UNSET
+        if not isinstance(self.updated_at, Unset):
+            updated_at = self.updated_at.isoformat()
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({})
+        if id is not UNSET:
+            field_dict["id"] = id
+        if customer_id is not UNSET:
+            field_dict["customer_id"] = customer_id
+        if status is not UNSET:
+            field_dict["status"] = status
+        if items is not UNSET:
+            field_dict["items"] = items
+        if total_amount is not UNSET:
+            field_dict["total_amount"] = total_amount
+        if currency is not UNSET:
+            field_dict["currency"] = currency
+        if shipping_address is not UNSET:
+            field_dict["shipping_address"] = shipping_address
+        if tracking_number is not UNSET:
+            field_dict["tracking_number"] = tracking_number
+        if created_at is not UNSET:
+            field_dict["created_at"] = created_at
+        if updated_at is not UNSET:
+            field_dict["updated_at"] = updated_at
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        d = src_dict.copy()
+        id = d.pop("id", UNSET)
+        customer_id = d.pop("customer_id", UNSET)
+        _status = d.pop("status", UNSET)
+        status: Union[Unset, OrderStatus]
+        if isinstance(_status, Unset):
+            status = UNSET
+        else:
+            status = OrderStatus(_status)
+        _items = d.pop("items", UNSET)
+        items: Union[Unset, List[OrderItem]] = UNSET
+        if not isinstance(_items, Unset):
+            items = [OrderItem.from_dict(item) for item in _items]
+        total_amount = d.pop("total_amount", UNSET)
+        currency = d.pop("currency", UNSET)
+        shipping_address = d.pop("shipping_address", UNSET)
+        tracking_number = d.pop("tracking_number", UNSET)
+        _created_at = d.pop("created_at", UNSET)
+        created_at: Union[Unset, datetime.datetime]
+        if isinstance(_created_at, Unset):
+            created_at = UNSET
+        else:
+            created_at = isoparse(_created_at)
+        _updated_at = d.pop("updated_at", UNSET)
+        updated_at: Union[Unset, datetime.datetime]
+        if isinstance(_updated_at, Unset):
+            updated_at = UNSET
+        else:
+            updated_at = isoparse(_updated_at)
+
+        order = cls(
+            id=id,
+            customer_id=customer_id,
+            status=status,
+            items=items,
+            total_amount=total_amount,
+            currency=currency,
+            shipping_address=shipping_address,
+            tracking_number=tracking_number,
+            created_at=created_at,
+            updated_at=updated_at,
+        )
+
+        order.additional_properties = d
+        return order
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/resources/order_resource.py
+++ b/resources/order_resource.py
@@ -2,44 +2,17 @@
 Example implementation of a specific Stateset resource (Orders).
 """
 
-from typing import Any, Dict, List, Optional
 from datetime import datetime
-from attrs import define, field
+from typing import Any, Dict, List, Optional
 
+from attrs import define
+
+from ..client import AuthenticatedClient
 from ..base_resource import BaseResource
-from ..stateset_types import StatesetObject, StatesetID, OrderStatus, Metadata
+from ..models.order import Order
 
 
 @define
-class OrderItem:
-    """Represents an item in an order."""
-
-    product_id: StatesetID
-    quantity: int
-    price: float
-    currency: str = field(default="USD")
-    metadata: Metadata = field(factory=dict)
-
-
-@define
-class Order(StatesetObject):
-    """Represents a Stateset Order."""
-
-    customer_id: StatesetID
-    status: OrderStatus
-    items: List[OrderItem]
-    total_amount: float
-    currency: str = field(default="USD")
-    shipping_address: Optional[Dict[str, str]] = None
-    tracking_number: Optional[str] = None
-
-    def __attrs_post_init__(self) -> None:
-        super().__attrs_post_init__()
-        # Convert item dictionaries to OrderItem objects
-        if self.items and isinstance(self.items[0], dict):
-            self.items = [OrderItem(**item) for item in self.items]
-
-
 class Orders(BaseResource[Order]):
     """Operations on Stateset Orders."""
 
@@ -50,7 +23,7 @@ class Orders(BaseResource[Order]):
         """Cancel an order."""
         data = {"reason": reason} if reason else {}
         response = await self.client.post(f"{self.base_path}/{id}/cancel", json=data)
-        return Order(**response)
+        return Order.from_dict(response)
 
     async def mark_as_shipped(
         self,
@@ -66,11 +39,11 @@ class Orders(BaseResource[Order]):
             "shipped_at": shipped_at.isoformat() if shipped_at else None,
         }
         response = await self.client.post(f"{self.base_path}/{id}/ship", json=data)
-        return Order(**response)
+        return Order.from_dict(response)
 
     async def add_items(self, id: str, items: List[Dict[str, Any]]) -> Order:
         """Add items to an existing order."""
         response = await self.client.post(
             f"{self.base_path}/{id}/items", json={"items": items}
         )
-        return Order(**response)
+        return Order.from_dict(response)


### PR DESCRIPTION
## Summary
- implement `Order` model
- expose new async order operations via `Orders` resource
- add API endpoints for creating, retrieving, updating, and deleting orders
- document order creation example in README

## Testing
- `python -m compileall -q .`