### PR TITLE
Implement order API helpers

### DIFF
--- a/api/orders/create_order.py
+++ b/api/orders/create_order.py
@@ -10,7 +10,7 @@ from ...stateset_types import Response
 
 
 def _get_kwargs(*, json_body: Order) -> Dict[str, Any]:
-    pass
+    """Build keyword arguments for the request."""
 
     json_json_body = json_body.to_dict()
 

--- a/api/orders/delete_order.py
+++ b/api/orders/delete_order.py
@@ -9,7 +9,7 @@ from ...stateset_types import Response
 
 
 def _get_kwargs(id: str) -> Dict[str, Any]:
-    pass
+    """Build keyword arguments for deleting an order."""
 
     return {
         "method": "delete",

--- a/api/orders/get_order_by_id.py
+++ b/api/orders/get_order_by_id.py
@@ -10,7 +10,7 @@ from ...stateset_types import Response
 
 
 def _get_kwargs(id: str) -> Dict[str, Any]:
-    pass
+    """Build keyword arguments for get_order_by_id request."""
 
     return {
         "method": "get",

--- a/api/orders/get_orders.py
+++ b/api/orders/get_orders.py
@@ -10,7 +10,7 @@ from ...stateset_types import UNSET, Response
 
 
 def _get_kwargs(*, limit: float, offset: float, order_direction: str) -> Dict[str, Any]:
-    pass
+    """Build kwargs for listing orders."""
 
     params: Dict[str, Any] = {}
     params["limit"] = limit

--- a/api/orders/update_order.py
+++ b/api/orders/update_order.py
@@ -10,7 +10,7 @@ from ...stateset_types import Response
 
 
 def _get_kwargs(id: str, *, json_body: Order) -> Dict[str, Any]:
-    pass
+    """Build keyword arguments for updating an order."""
 
     json_json_body = json_body.to_dict()
 


### PR DESCRIPTION
## Summary
- complete `_get_kwargs` implementations for order API helpers

## Testing
- `pytest -q` *(fails: command not found)*