### PR TITLE
Add generic model and missing resource stubs

### DIFF
--- a/models/__init__.py
+++ b/models/__init__.py
@@ -22,6 +22,7 @@ from .warranty import Warranty
 from .warranty_item import WarrantyItem
 from .work_order import WorkOrder
 from .work_order_line_items import WorkOrderLineItems
+from .generic import GenericModel
 
 __all__ = (
     "BillOfMaterials",
@@ -46,4 +47,5 @@ __all__ = (
     "Attribute",
     "Knowledge",
     "Eval",
+    "GenericModel",
 )

--- a/models/generic.py
+++ b/models/generic.py
@@ -1,0 +1,18 @@
+from typing import Any, Dict
+from attrs import define, field
+
+@define
+class GenericModel:
+    """Fallback model for resources without a specific schema."""
+
+    additional_properties: Dict[str, Any] = field(init=False, factory=dict)
+
+    def __init__(self, **kwargs: Any) -> None:
+        self.additional_properties = dict(kwargs)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return dict(self.additional_properties)
+
+    @classmethod
+    def from_dict(cls, src: Dict[str, Any]) -> "GenericModel":
+        return cls(**src)

--- a/resources/asset_resource.py
+++ b/resources/asset_resource.py
@@ -1,0 +1,11 @@
+from attrs import define
+from ..client import AuthenticatedClient
+from ..models.generic import GenericModel
+from ..base_resource import BaseResource
+
+@define
+class Assets(BaseResource[GenericModel]):
+    """Operations on Stateset Assets."""
+
+    def __init__(self, client: AuthenticatedClient) -> None:
+        super().__init__(client, GenericModel, "/assets")

--- a/resources/bill_of_material_resource.py
+++ b/resources/bill_of_material_resource.py
@@ -1,0 +1,11 @@
+from attrs import define
+from ..client import AuthenticatedClient
+from ..models.bill_of_materials import BillOfMaterials
+from ..base_resource import BaseResource
+
+@define
+class BillOfMaterials(BaseResource[BillOfMaterials]):
+    """Operations on Stateset BillOfMaterials."""
+
+    def __init__(self, client: AuthenticatedClient) -> None:
+        super().__init__(client, BillOfMaterials, "/billofmaterials")

--- a/resources/channel_resource.py
+++ b/resources/channel_resource.py
@@ -1,0 +1,11 @@
+from attrs import define
+from ..client import AuthenticatedClient
+from ..models.generic import GenericModel
+from ..base_resource import BaseResource
+
+@define
+class Channels(BaseResource[GenericModel]):
+    """Operations on Stateset Channels."""
+
+    def __init__(self, client: AuthenticatedClient) -> None:
+        super().__init__(client, GenericModel, "/channels")

--- a/resources/compliance_resource.py
+++ b/resources/compliance_resource.py
@@ -1,0 +1,11 @@
+from attrs import define
+from ..client import AuthenticatedClient
+from ..models.generic import GenericModel
+from ..base_resource import BaseResource
+
+@define
+class Compliance(BaseResource[GenericModel]):
+    """Operations on Stateset Compliance."""
+
+    def __init__(self, client: AuthenticatedClient) -> None:
+        super().__init__(client, GenericModel, "/compliances")

--- a/resources/contract_resource.py
+++ b/resources/contract_resource.py
@@ -1,0 +1,11 @@
+from attrs import define
+from ..client import AuthenticatedClient
+from ..models.generic import GenericModel
+from ..base_resource import BaseResource
+
+@define
+class Contracts(BaseResource[GenericModel]):
+    """Operations on Stateset Contracts."""
+
+    def __init__(self, client: AuthenticatedClient) -> None:
+        super().__init__(client, GenericModel, "/contracts")

--- a/resources/cycle_count_resource.py
+++ b/resources/cycle_count_resource.py
@@ -1,0 +1,11 @@
+from attrs import define
+from ..client import AuthenticatedClient
+from ..models.generic import GenericModel
+from ..base_resource import BaseResource
+
+@define
+class CycleCounts(BaseResource[GenericModel]):
+    """Operations on Stateset CycleCounts."""
+
+    def __init__(self, client: AuthenticatedClient) -> None:
+        super().__init__(client, GenericModel, "/cyclecounts")

--- a/resources/inventory_resource.py
+++ b/resources/inventory_resource.py
@@ -1,0 +1,11 @@
+from attrs import define
+from ..client import AuthenticatedClient
+from ..models.inventory_items import InventoryItems
+from ..base_resource import BaseResource
+
+@define
+class Inventory(BaseResource[InventoryItems]):
+    """Operations on Stateset Inventory."""
+
+    def __init__(self, client: AuthenticatedClient) -> None:
+        super().__init__(client, InventoryItems, "/inventoryitems")

--- a/resources/invoice_line_resource.py
+++ b/resources/invoice_line_resource.py
@@ -1,0 +1,11 @@
+from attrs import define
+from ..client import AuthenticatedClient
+from ..models.generic import GenericModel
+from ..base_resource import BaseResource
+
+@define
+class InvoiceLines(BaseResource[GenericModel]):
+    """Operations on Stateset InvoiceLines."""
+
+    def __init__(self, client: AuthenticatedClient) -> None:
+        super().__init__(client, GenericModel, "/invoicelines")

--- a/resources/invoice_resource.py
+++ b/resources/invoice_resource.py
@@ -1,0 +1,11 @@
+from attrs import define
+from ..client import AuthenticatedClient
+from ..models.generic import GenericModel
+from ..base_resource import BaseResource
+
+@define
+class Invoices(BaseResource[GenericModel]):
+    """Operations on Stateset Invoices."""
+
+    def __init__(self, client: AuthenticatedClient) -> None:
+        super().__init__(client, GenericModel, "/invoices")

--- a/resources/lead_resource.py
+++ b/resources/lead_resource.py
@@ -1,0 +1,11 @@
+from attrs import define
+from ..client import AuthenticatedClient
+from ..models.generic import GenericModel
+from ..base_resource import BaseResource
+
+@define
+class Leads(BaseResource[GenericModel]):
+    """Operations on Stateset Leads."""
+
+    def __init__(self, client: AuthenticatedClient) -> None:
+        super().__init__(client, GenericModel, "/leads")

--- a/resources/location_resource.py
+++ b/resources/location_resource.py
@@ -1,0 +1,11 @@
+from attrs import define
+from ..client import AuthenticatedClient
+from ..models.generic import GenericModel
+from ..base_resource import BaseResource
+
+@define
+class Locations(BaseResource[GenericModel]):
+    """Operations on Stateset Locations."""
+
+    def __init__(self, client: AuthenticatedClient) -> None:
+        super().__init__(client, GenericModel, "/locations")

--- a/resources/log_resource.py
+++ b/resources/log_resource.py
@@ -1,0 +1,11 @@
+from attrs import define
+from ..client import AuthenticatedClient
+from ..models.generic import GenericModel
+from ..base_resource import BaseResource
+
+@define
+class Logs(BaseResource[GenericModel]):
+    """Operations on Stateset Logs."""
+
+    def __init__(self, client: AuthenticatedClient) -> None:
+        super().__init__(client, GenericModel, "/logs")

--- a/resources/machine_resource.py
+++ b/resources/machine_resource.py
@@ -1,0 +1,11 @@
+from attrs import define
+from ..client import AuthenticatedClient
+from ..models.generic import GenericModel
+from ..base_resource import BaseResource
+
+@define
+class Machines(BaseResource[GenericModel]):
+    """Operations on Stateset Machines."""
+
+    def __init__(self, client: AuthenticatedClient) -> None:
+        super().__init__(client, GenericModel, "/machines")

--- a/resources/manufacture_order_line_resource.py
+++ b/resources/manufacture_order_line_resource.py
@@ -1,0 +1,11 @@
+from attrs import define
+from ..client import AuthenticatedClient
+from ..models.manufacture_order_line_item import ManufactureOrderLineItem
+from ..base_resource import BaseResource
+
+@define
+class ManufactureOrderLines(BaseResource[ManufactureOrderLineItem]):
+    """Operations on Stateset ManufactureOrderLines."""
+
+    def __init__(self, client: AuthenticatedClient) -> None:
+        super().__init__(client, ManufactureOrderLineItem, "/manufactureorderitems")

--- a/resources/manufacture_order_resource.py
+++ b/resources/manufacture_order_resource.py
@@ -1,0 +1,11 @@
+from attrs import define
+from ..client import AuthenticatedClient
+from ..models.manufacture_order import ManufactureOrder
+from ..base_resource import BaseResource
+
+@define
+class ManufactureOrders(BaseResource[ManufactureOrder]):
+    """Operations on Stateset ManufactureOrders."""
+
+    def __init__(self, client: AuthenticatedClient) -> None:
+        super().__init__(client, ManufactureOrder, "/manufactureorders")

--- a/resources/order_line_resource.py
+++ b/resources/order_line_resource.py
@@ -1,0 +1,11 @@
+from attrs import define
+from ..client import AuthenticatedClient
+from ..models.generic import GenericModel
+from ..base_resource import BaseResource
+
+@define
+class OrderLines(BaseResource[GenericModel]):
+    """Operations on Stateset OrderLines."""
+
+    def __init__(self, client: AuthenticatedClient) -> None:
+        super().__init__(client, GenericModel, "/orderlines")

--- a/resources/payout_resource.py
+++ b/resources/payout_resource.py
@@ -1,0 +1,11 @@
+from attrs import define
+from ..client import AuthenticatedClient
+from ..models.generic import GenericModel
+from ..base_resource import BaseResource
+
+@define
+class Payouts(BaseResource[GenericModel]):
+    """Operations on Stateset Payouts."""
+
+    def __init__(self, client: AuthenticatedClient) -> None:
+        super().__init__(client, GenericModel, "/payouts")

--- a/resources/pick_resource.py
+++ b/resources/pick_resource.py
@@ -1,0 +1,11 @@
+from attrs import define
+from ..client import AuthenticatedClient
+from ..models.generic import GenericModel
+from ..base_resource import BaseResource
+
+@define
+class Picks(BaseResource[GenericModel]):
+    """Operations on Stateset Picks."""
+
+    def __init__(self, client: AuthenticatedClient) -> None:
+        super().__init__(client, GenericModel, "/picks")

--- a/resources/product_resource.py
+++ b/resources/product_resource.py
@@ -1,0 +1,11 @@
+from attrs import define
+from ..client import AuthenticatedClient
+from ..models.generic import GenericModel
+from ..base_resource import BaseResource
+
+@define
+class Products(BaseResource[GenericModel]):
+    """Operations on Stateset Products."""
+
+    def __init__(self, client: AuthenticatedClient) -> None:
+        super().__init__(client, GenericModel, "/products")

--- a/resources/promotion_resource.py
+++ b/resources/promotion_resource.py
@@ -1,0 +1,11 @@
+from attrs import define
+from ..client import AuthenticatedClient
+from ..models.generic import GenericModel
+from ..base_resource import BaseResource
+
+@define
+class Promotions(BaseResource[GenericModel]):
+    """Operations on Stateset Promotions."""
+
+    def __init__(self, client: AuthenticatedClient) -> None:
+        super().__init__(client, GenericModel, "/promotions")

--- a/resources/purchase_order_line_resource.py
+++ b/resources/purchase_order_line_resource.py
@@ -1,0 +1,11 @@
+from attrs import define
+from ..client import AuthenticatedClient
+from ..models.generic import GenericModel
+from ..base_resource import BaseResource
+
+@define
+class PurchaseOrderLines(BaseResource[GenericModel]):
+    """Operations on Stateset PurchaseOrderLines."""
+
+    def __init__(self, client: AuthenticatedClient) -> None:
+        super().__init__(client, GenericModel, "/purchaseorderlines")

--- a/resources/purchase_order_resource.py
+++ b/resources/purchase_order_resource.py
@@ -1,0 +1,11 @@
+from attrs import define
+from ..client import AuthenticatedClient
+from ..models.generic import GenericModel
+from ..base_resource import BaseResource
+
+@define
+class PurchaseOrders(BaseResource[GenericModel]):
+    """Operations on Stateset PurchaseOrders."""
+
+    def __init__(self, client: AuthenticatedClient) -> None:
+        super().__init__(client, GenericModel, "/purchaseorders")

--- a/resources/schedule_resource.py
+++ b/resources/schedule_resource.py
@@ -1,0 +1,11 @@
+from attrs import define
+from ..client import AuthenticatedClient
+from ..models.generic import GenericModel
+from ..base_resource import BaseResource
+
+@define
+class Schedule(BaseResource[GenericModel]):
+    """Operations on Stateset Schedule."""
+
+    def __init__(self, client: AuthenticatedClient) -> None:
+        super().__init__(client, GenericModel, "/schedule")

--- a/resources/settlement_resource.py
+++ b/resources/settlement_resource.py
@@ -1,0 +1,11 @@
+from attrs import define
+from ..client import AuthenticatedClient
+from ..models.generic import GenericModel
+from ..base_resource import BaseResource
+
+@define
+class Settlements(BaseResource[GenericModel]):
+    """Operations on Stateset Settlements."""
+
+    def __init__(self, client: AuthenticatedClient) -> None:
+        super().__init__(client, GenericModel, "/settlements")

--- a/resources/ship_to_resource.py
+++ b/resources/ship_to_resource.py
@@ -1,0 +1,11 @@
+from attrs import define
+from ..client import AuthenticatedClient
+from ..models.generic import GenericModel
+from ..base_resource import BaseResource
+
+@define
+class ShipTo(BaseResource[GenericModel]):
+    """Operations on Stateset ShipTo."""
+
+    def __init__(self, client: AuthenticatedClient) -> None:
+        super().__init__(client, GenericModel, "/shipto")

--- a/resources/shipment_line_resource.py
+++ b/resources/shipment_line_resource.py
@@ -1,0 +1,11 @@
+from attrs import define
+from ..client import AuthenticatedClient
+from ..models.generic import GenericModel
+from ..base_resource import BaseResource
+
+@define
+class ShipmentLines(BaseResource[GenericModel]):
+    """Operations on Stateset ShipmentLines."""
+
+    def __init__(self, client: AuthenticatedClient) -> None:
+        super().__init__(client, GenericModel, "/shipmentlines")

--- a/resources/shipment_resource.py
+++ b/resources/shipment_resource.py
@@ -1,0 +1,11 @@
+from attrs import define
+from ..client import AuthenticatedClient
+from ..models.generic import GenericModel
+from ..base_resource import BaseResource
+
+@define
+class Shipments(BaseResource[GenericModel]):
+    """Operations on Stateset Shipments."""
+
+    def __init__(self, client: AuthenticatedClient) -> None:
+        super().__init__(client, GenericModel, "/shipments")

--- a/resources/supplier_resource.py
+++ b/resources/supplier_resource.py
@@ -1,0 +1,11 @@
+from attrs import define
+from ..client import AuthenticatedClient
+from ..models.generic import GenericModel
+from ..base_resource import BaseResource
+
+@define
+class Suppliers(BaseResource[GenericModel]):
+    """Operations on Stateset Suppliers."""
+
+    def __init__(self, client: AuthenticatedClient) -> None:
+        super().__init__(client, GenericModel, "/suppliers")

--- a/resources/user_resource.py
+++ b/resources/user_resource.py
@@ -1,0 +1,11 @@
+from attrs import define
+from ..client import AuthenticatedClient
+from ..models.generic import GenericModel
+from ..base_resource import BaseResource
+
+@define
+class Users(BaseResource[GenericModel]):
+    """Operations on Stateset Users."""
+
+    def __init__(self, client: AuthenticatedClient) -> None:
+        super().__init__(client, GenericModel, "/users")

--- a/resources/vendor_resource.py
+++ b/resources/vendor_resource.py
@@ -1,0 +1,11 @@
+from attrs import define
+from ..client import AuthenticatedClient
+from ..models.generic import GenericModel
+from ..base_resource import BaseResource
+
+@define
+class Vendors(BaseResource[GenericModel]):
+    """Operations on Stateset Vendors."""
+
+    def __init__(self, client: AuthenticatedClient) -> None:
+        super().__init__(client, GenericModel, "/vendors")

--- a/resources/waste_and_scrap_resource.py
+++ b/resources/waste_and_scrap_resource.py
@@ -1,0 +1,11 @@
+from attrs import define
+from ..client import AuthenticatedClient
+from ..models.generic import GenericModel
+from ..base_resource import BaseResource
+
+@define
+class WasteAndScrap(BaseResource[GenericModel]):
+    """Operations on Stateset WasteAndScrap."""
+
+    def __init__(self, client: AuthenticatedClient) -> None:
+        super().__init__(client, GenericModel, "/wasteandscrap")

--- a/resources/workflow_resource.py
+++ b/resources/workflow_resource.py
@@ -1,0 +1,11 @@
+from attrs import define
+from ..client import AuthenticatedClient
+from ..models.generic import GenericModel
+from ..base_resource import BaseResource
+
+@define
+class Workflows(BaseResource[GenericModel]):
+    """Operations on Stateset Workflows."""
+
+    def __init__(self, client: AuthenticatedClient) -> None:
+        super().__init__(client, GenericModel, "/workflows")

--- a/resources/workorder_line_resource.py
+++ b/resources/workorder_line_resource.py
@@ -1,0 +1,11 @@
+from attrs import define
+from ..client import AuthenticatedClient
+from ..models.work_order_line_items import WorkOrderLineItems
+from ..base_resource import BaseResource
+
+@define
+class WorkOrderLines(BaseResource[WorkOrderLineItems]):
+    """Operations on Stateset WorkOrderLines."""
+
+    def __init__(self, client: AuthenticatedClient) -> None:
+        super().__init__(client, WorkOrderLineItems, "/workorderitems")

--- a/resources/workorder_resource.py
+++ b/resources/workorder_resource.py
@@ -1,0 +1,11 @@
+from attrs import define
+from ..client import AuthenticatedClient
+from ..models.work_order import WorkOrder
+from ..base_resource import BaseResource
+
+@define
+class WorkOrders(BaseResource[WorkOrder]):
+    """Operations on Stateset WorkOrders."""
+
+    def __init__(self, client: AuthenticatedClient) -> None:
+        super().__init__(client, WorkOrder, "/workorders")


### PR DESCRIPTION
## Summary
- add a `GenericModel` for resources without defined schemas
- export `GenericModel` from `models.__init__`
- provide stubs for many missing resources using `GenericModel` or existing models

## Testing
- `pytest -q`