### PR TITLE
Improve resource pagination helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,8 @@ Things to know:
 1. All path/query params, and bodies become method arguments.
 1. If your endpoint had any tags on it, the first tag will be used as a module name for the function (my_tag above)
 1. Any endpoint which did not have a tag will be in `stateset_client.api.default`
+1. Every resource class includes an `iter_all` method to iterate through all
+   pages of results, and a `list_all` helper that returns a full list.
 
 ## Advanced customizations
 

--- a/base_resource.py
+++ b/base_resource.py
@@ -2,48 +2,37 @@
 Base resource class that implements common functionality for all Stateset API resources.
 """
 
-from typing import Any, Dict, Generic, List, Optional, Type, TypeVar
+from typing import Any, Dict, Generic, List, Optional, Type, TypeVar, AsyncIterator
 from .client import AuthenticatedClient
 from .stateset_types import PaginatedList, PaginationParams
 
 T = TypeVar("T")
 
+
 class BaseResource(Generic[T]):
     """Base class for all Stateset API resources."""
-    
+
     def __init__(
-        self,
-        client: AuthenticatedClient,
-        object_class: Type[T],
-        base_path: str
+        self, client: AuthenticatedClient, object_class: Type[T], base_path: str
     ) -> None:
         self.client = client
         self.object_class = object_class
         self.base_path = base_path
 
     async def list(
-        self,
-        params: Optional[PaginationParams] = None,
-        **kwargs: Any
+        self, params: Optional[PaginationParams] = None, **kwargs: Any
     ) -> PaginatedList[T]:
         """List all resources with pagination support."""
         params = params or PaginationParams()
-        query_params = {
-            "page": params.page,
-            "per_page": params.per_page,
-            **kwargs
-        }
-        
+        query_params = {"page": params.page, "per_page": params.per_page, **kwargs}
+
         if params.sort_by:
             query_params["sort_by"] = params.sort_by
             if params.sort_order:
                 query_params["sort_order"] = params.sort_order
 
-        response = await self.client.get(
-            path=self.base_path,
-            params=query_params
-        )
-        
+        response = await self.client.get(path=self.base_path, params=query_params)
+
         data = [self.object_class(**item) for item in response["data"]]
         return PaginatedList(
             data=data,
@@ -52,7 +41,7 @@ class BaseResource(Generic[T]):
             per_page=response["per_page"],
             total_pages=response["total_pages"],
             has_next=response["has_next"],
-            has_prev=response["has_prev"]
+            has_prev=response["has_prev"],
         )
 
     async def get(self, id: str) -> T:
@@ -73,3 +62,31 @@ class BaseResource(Generic[T]):
     async def delete(self, id: str) -> None:
         """Delete a resource."""
         await self.client.delete(f"{self.base_path}/{id}")
+
+    async def iter_all(
+        self,
+        params: Optional[PaginationParams] = None,
+        **kwargs: Any,
+    ) -> AsyncIterator[T]:
+        """Iterate through all items across paginated results."""
+
+        params = params or PaginationParams()
+        while True:
+            page = await self.list(params=params, **kwargs)
+            for item in page.data:
+                yield item
+            if not page.has_next:
+                break
+            params.page = page.next_page or params.page + 1
+
+    async def list_all(
+        self,
+        params: Optional[PaginationParams] = None,
+        **kwargs: Any,
+    ) -> List[T]:
+        """Return a list containing all items from all pages."""
+
+        items: List[T] = []
+        async for item in self.iter_all(params=params, **kwargs):
+            items.append(item)
+        return items


### PR DESCRIPTION
## Summary
- add convenient `iter_all` and `list_all` helpers to BaseResource
- document the new pagination helpers in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684073efc6c8832ebb73573701374d67